### PR TITLE
Fix buffer position handling in ValueList

### DIFF
--- a/ValueCollections/ValueDictionary/ValueDictionary.cs
+++ b/ValueCollections/ValueDictionary/ValueDictionary.cs
@@ -591,9 +591,10 @@ public ref partial struct ValueDictionary<TKey, TValue> : IDisposable, IDictiona
 
         Buffer[(index + 1)..].CopyTo(Buffer[index..]);
         HashCodes[(index + 1)..].CopyTo(HashCodes[index..]);
+
+        BufferPosition--;
         Buffer[BufferPosition] = default!;
         HashCodes[BufferPosition] = default!;
-        BufferPosition--;
     }
 
     /// <summary>

--- a/ValueCollections/ValueHashSet/ValueHashSet.cs
+++ b/ValueCollections/ValueHashSet/ValueHashSet.cs
@@ -671,9 +671,10 @@ public ref partial struct ValueHashSet<T> : IDisposable, ISet<T>, IReadOnlySet<T
 
         Buffer[(index + 1)..].CopyTo(Buffer[index..]);
         HashCodes[(index + 1)..].CopyTo(HashCodes[index..]);
+
+        BufferPosition--;
         Buffer[BufferPosition] = default!;
         HashCodes[BufferPosition] = default!;
-        BufferPosition--;
     }
 
     /// <summary>

--- a/ValueCollections/ValueList/ValueList.cs
+++ b/ValueCollections/ValueList/ValueList.cs
@@ -322,8 +322,9 @@ public ref partial struct ValueList<T> : IDisposable, IList<T>, IReadOnlyList<T>
         ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, BufferPosition);
 
         Buffer[(index + 1)..].CopyTo(Buffer[index..]);
-        Buffer[BufferPosition] = default!;
+        
         BufferPosition--;
+        Buffer[BufferPosition] = default!;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes an off-by-one error in RemoveAt.

BufferPosition represents the element count. Clearing Buffer[BufferPosition] can access an invalid index when removing the last element.

Decrement BufferPosition first, then clear the unused slot.